### PR TITLE
Workaround in RPC.Eth.EthGetCode to allow [] as return value from server

### DIFF
--- a/src/Nethereum.RPC/Eth/EthGetCode.cs
+++ b/src/Nethereum.RPC/Eth/EthGetCode.cs
@@ -49,12 +49,24 @@ namespace Nethereum.RPC.Eth
             return base.SendRequestAsync(id, cancellationToken, address.EnsureHexPrefix(), block);
         }
 
-        public Task<string> SendRequestAsync(string address,
+        public async Task<string> SendRequestAsync(string address,
                                              object id = null,
                                              CancellationToken cancellationToken = default(CancellationToken))
         {
             if (address == null) throw new ArgumentNullException(nameof(address));
-            return base.SendRequestAsync(id, cancellationToken, address.EnsureHexPrefix(), DefaultBlock);
+            var res = await base.Client.SendRequestAsync<object>(this.BuildRequest(address.EnsureHexPrefix(), DefaultBlock, id));
+            // Some servers may return empty array for non-contract addresses instead of "0x", so check for array
+            if (res is Newtonsoft.Json.Linq.JArray)
+            {
+                var array = res as Newtonsoft.Json.Linq.JArray;
+                if (!array.HasValues)
+                    return "0x";
+                else
+                    throw new Exceptions.UnexpectedReplyException(
+                        "Unexpected response value: " + array.ToString(Newtonsoft.Json.Formatting.None), 
+                        array);
+            }
+            return (string)res;
         }
 
         public RpcRequest BuildRequest(string address, BlockParameter block, object id = null)

--- a/src/Nethereum.RPC/Eth/Exceptions/UnexpectedReplyException.cs
+++ b/src/Nethereum.RPC/Eth/Exceptions/UnexpectedReplyException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Nethereum.RPC.Eth.Exceptions
+{
+    public class UnexpectedReplyException : Exception
+    {
+        public UnexpectedReplyException(string message, object resultValue) : base(message)
+        {
+            ResultValue = resultValue;
+        }
+        public object ResultValue { get; set; }
+    }
+}


### PR DESCRIPTION
Some servers, like `nodes.mewapi.io/rpc/eth` and `www.ethercluster.com/etc`,
return empty array instead of "0x" for non-contract addresses.
Example: `{"jsonrpc":"2.0","id":1,"result":[]}`.
Handle that case and return "0x".
In case of non-empty array, throw UnexpectedReplyException.

Upstream PR: #866

